### PR TITLE
Set daemon = True for threads

### DIFF
--- a/dassana/common.py
+++ b/dassana/common.py
@@ -132,7 +132,7 @@ def iterate_and_update_job_status():
         patch_ingestion(job_id)
         logger.info(f"Updated job status for job id: {job_id}")
 
-threading.Thread(target=lambda: every(1800, iterate_and_update_job_status)).start()
+threading.Thread(target=lambda: every(1800, iterate_and_update_job_status, daemon=True)).start()
 
 @retry(reraise=True,
     before_sleep=before_sleep_log(logger, logging.INFO),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="dassana",
-    version="0.10.13",
+    version="0.10.14",
     description="Dassana common data ingestion utilities",
     long_description="Dassana common data ingestion utilities",
     url="https://github.com/dassana-io/dassana-python",


### PR DESCRIPTION
From the [docs](https://docs.python.org/3/library/threading.html)
A thread can be flagged as a “daemon thread”. The significance of this flag is that the entire Python program exits when only daemon threads are left. Daemon threads are abruptly stopped at shutdown.